### PR TITLE
feat(status): add chain status command with forge abstraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # They are all for CI and tests
 # `dev` uses no gems
 
+gem "logger"
+
 group :development, :test do
   gem "rubocop", "~> 1.13.0"
   gem "rubocop-performance"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,26 +2,30 @@ GEM
   remote: https://rubygems.org/
   specs:
     ansi (1.5.0)
-    ast (2.4.2)
+    ast (2.4.3)
     builder (3.3.0)
-    minitest (5.17.0)
+    drb (2.2.3)
+    logger (1.7.0)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
     minitest-reporters (1.7.1)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (2.4.5)
+    mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
-    parallel (1.24.0)
-    parser (3.3.1.0)
+    parallel (1.27.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    racc (1.7.3)
+    prism (1.9.0)
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
-    regexp_parser (2.9.2)
-    rexml (3.3.3)
-      strscan
+    rake (13.3.1)
+    regexp_parser (2.11.3)
+    rexml (3.4.4)
     rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -31,11 +35,12 @@ GEM
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
     rubocop-minitest (0.27.0)
       rubocop (>= 0.90, < 2.0)
-    rubocop-performance (1.17.1)
+    rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rake (0.6.0)
@@ -44,13 +49,14 @@ GEM
       rubocop (~> 1.11)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    strscan (3.1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
+  logger
   minitest (>= 5.0.0)
   minitest-reporters
   mocha
@@ -61,5 +67,32 @@ DEPENDENCIES
   rubocop-rake
   rubocop-shopify (~> 2.0.1)
 
+CHECKSUMS
+  ansi (1.5.0) sha256=5408253274e33d9d27d4a98c46d2998266fd51cba58a7eb9d08f50e57ed23592
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest-reporters (1.7.1) sha256=5060413a0c95b8c32fe73e0606f3631c173a884d7900e50013e15094eb50562c
+  mocha (3.1.0) sha256=75f42d69ebfb1f10b32489dff8f8431d37a418120ecdfc07afe3bc183d4e1d56
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.13.0) sha256=4d24d2557ad91ebf0c316c7da4e4b96c2e293ae32ab6760510bc650e8e91f931
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-minitest (0.27.0) sha256=5b4801446a10fbf351c0142ddc416ca102328190b90c86a775a24e95581fdaa9
+  rubocop-performance (1.19.1) sha256=52664172d944eb45d478ed6d04c8b02c36cf0ee15726fabb6c90a95ca5cdfadf
+  rubocop-rake (0.6.0) sha256=56b6f22189af4b33d4f4e490a555c09f1281b02f4d48c3a61f6e8fe5f401d8db
+  rubocop-shopify (2.0.1) sha256=0f0a52a2cc0ab8e8990e2af6abe099743b67aaaf827d42ba7e53163d1e7d76d1
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+
 BUNDLED WITH
-   2.2.33
+  4.0.9

--- a/lib/git_chain.rb
+++ b/lib/git_chain.rb
@@ -14,6 +14,7 @@ module GitChain
 
   autoload :Commands, "git_chain/commands"
   autoload :EntryPoint, "git_chain/entry_point"
+  autoload :Forge, "git_chain/forge"
   autoload :Git, "git_chain/git"
   autoload :Models, "git_chain/models"
   autoload :Options, "git_chain/options"

--- a/lib/git_chain/commands.rb
+++ b/lib/git_chain/commands.rb
@@ -8,6 +8,7 @@ module GitChain
     autoload :Prune, "git_chain/commands/prune"
     autoload :Push, "git_chain/commands/push"
     autoload :Setup, "git_chain/commands/setup"
+    autoload :Status, "git_chain/commands/status"
     autoload :Teardown, "git_chain/commands/teardown"
 
     ArgError = Class.new(ArgumentError)

--- a/lib/git_chain/commands/status.rb
+++ b/lib/git_chain/commands/status.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+require "optparse"
+
+module GitChain
+  module Commands
+    class Status < Command
+      include Options::ChainName
+
+      def description
+        "Show status of the current chain"
+      end
+
+      def configure_option_parser(opts, options)
+        super
+
+        opts.on("--no-pr", "Skip PR status lookup") do
+          options[:no_pr] = true
+        end
+      end
+
+      def run(options)
+        chain = current_chain(options)
+        current_branch = Git.current_branch
+        branches = chain.branches
+        pr_info = options[:no_pr] ? {} : fetch_pr_info(chain)
+
+        puts("{{bold:#{chain.name}}}")
+
+        branches.each_with_index do |branch, index|
+          is_last = index == branches.size - 1
+          is_current = branch.name == current_branch
+          is_base = index == 0
+
+          connector = if is_base
+            ""
+          elsif is_last
+            "\u2514\u2500\u2500 "
+          else
+            "\u251C\u2500\u2500 "
+          end
+
+          indent = is_base ? "  " : "  "
+
+          name_str = if is_current
+            "{{yellow:#{branch.name}}} {{yellow:(HEAD)}}"
+          else
+            "{{cyan:#{branch.name}}}"
+          end
+
+          details = build_details(branch, is_base, pr_info)
+          puts("#{indent}#{connector}#{name_str}#{details}")
+        end
+      end
+
+      private
+
+      def build_details(branch, is_base, pr_info)
+        parts = []
+
+        unless is_base
+          counts = Git.ahead_behind(branch.name, branch.parent_branch)
+          if counts
+            ahead = counts[:ahead]
+            behind = counts[:behind]
+            if ahead > 0 || behind > 0
+              count_parts = []
+              count_parts << "#{ahead} ahead" if ahead > 0
+              count_parts << "#{behind} behind" if behind > 0
+              parts << count_parts.join(", ")
+            end
+          end
+        end
+
+        pr = pr_info[branch.name]
+        if pr
+          state = pr[:state]
+          state_str = case state
+          when "MERGED"
+            "{{green:merged}}"
+          when "CLOSED"
+            "{{red:closed}}"
+          when "OPEN"
+            pr[:is_draft] ? "{{cyan:draft}}" : "{{green:open}}"
+          else
+            state.downcase
+          end
+
+          parts << "##{pr[:number]} #{state_str}"
+
+          if pr[:review_decision] && state == "OPEN"
+            review_str = case pr[:review_decision]
+            when "APPROVED"
+              "{{green:approved}}"
+            when "CHANGES_REQUESTED"
+              "{{red:changes requested}}"
+            when "REVIEW_REQUIRED"
+              "review required"
+            end
+            parts << review_str if review_str
+          end
+        end
+
+        return "" if parts.empty?
+        " (#{parts.join(", ")})"
+      end
+
+      def fetch_pr_info(chain)
+        forge = Forge.detect(remote_url: chain.remote_url)
+        return {} unless forge&.cli_available?
+
+        info = {}
+        chain.branches.each do |branch|
+          next if branch.parent_branch.nil? # skip base branch
+          pr = forge.pr_for_branch(branch.name)
+          info[branch.name] = pr if pr
+        end
+        info
+      end
+    end
+  end
+end

--- a/lib/git_chain/forge.rb
+++ b/lib/git_chain/forge.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "open3"
+
+module GitChain
+  module Forge
+    autoload :Base, "git_chain/forge/base"
+    autoload :Github, "git_chain/forge/github"
+    autoload :Gitlab, "git_chain/forge/gitlab"
+
+    class << self
+      # Detect the forge from git config override or remote URL.
+      # Returns a forge adapter instance, or nil if detection fails.
+      def detect(remote_url: nil)
+        adapter = from_config_override
+        return adapter if adapter
+
+        remote_url ||= Git.remote_url(branch: Git.current_branch.to_s)
+        return nil if remote_url.nil? || remote_url.empty?
+
+        from_remote_url(remote_url)
+      end
+
+      private
+
+      def from_config_override
+        forge_type = Git.get_config("chain.forge")
+        return nil unless forge_type
+
+        case forge_type.downcase
+        when "github" then Github.new
+        when "gitlab" then Gitlab.new
+        end
+      end
+
+      def from_remote_url(url)
+        host = extract_host(url)
+        return nil unless host
+
+        case host
+        when /\Agithub\.com\z/ then Github.new
+        when /gitlab/ then Gitlab.new
+        end
+      end
+
+      # Extract the hostname from an SSH or HTTPS git remote URL.
+      # Handles:
+      #   https://github.com/user/repo.git
+      #   git@github.com:user/repo.git
+      #   ssh://git@github.com/user/repo.git
+      def extract_host(url)
+        if (match = url.match(%r{\A(?:https?|git)://([^/:]+)}))
+          match[1]
+        elsif (match = url.match(/\A[^@]+@([^:]+):/))
+          match[1]
+        end
+      end
+    end
+  end
+end

--- a/lib/git_chain/forge/base.rb
+++ b/lib/git_chain/forge/base.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module GitChain
+  module Forge
+    class Base
+      # Returns true if the forge CLI tool is installed and runnable.
+      def cli_available?
+        raise NotImplementedError
+      end
+
+      # Look up a PR/MR for the given branch.
+      # Returns a hash with normalized keys, or nil if none found:
+      #   { number:, state:, is_draft:, review_decision: }
+      #
+      # state is normalized to: "OPEN", "MERGED", "CLOSED"
+      # review_decision is normalized to: "APPROVED", "CHANGES_REQUESTED",
+      #   "REVIEW_REQUIRED", or nil
+      def pr_for_branch(_branch_name)
+        raise NotImplementedError
+      end
+
+      private
+
+      def command_available?(cmd)
+        _, _, stat = Open3.capture3(cmd, "--version")
+        stat.success?
+      rescue Errno::ENOENT
+        false
+      end
+    end
+  end
+end

--- a/lib/git_chain/forge/github.rb
+++ b/lib/git_chain/forge/github.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "open3"
+require "json"
+
+module GitChain
+  module Forge
+    class Github < Base
+      def cli_available?
+        command_available?("gh")
+      end
+
+      def pr_for_branch(branch_name)
+        fields = "number,state,isDraft,reviewDecision"
+        out, _, stat = Open3.capture3(
+          "gh", "pr", "list",
+          "--head", branch_name,
+          "--state", "all",
+          "--json", fields,
+          "--limit", "1"
+        )
+        return nil unless stat.success?
+
+        prs = JSON.parse(out)
+        return nil if prs.empty?
+
+        normalize(prs.first)
+      rescue JSON::ParserError, Errno::ENOENT
+        nil
+      end
+
+      private
+
+      # gh returns state as OPEN/MERGED/CLOSED, which matches our normalized format.
+      def normalize(pr)
+        {
+          number: pr["number"],
+          state: pr["state"],
+          is_draft: pr["isDraft"],
+          review_decision: pr["reviewDecision"],
+        }
+      end
+    end
+  end
+end

--- a/lib/git_chain/forge/gitlab.rb
+++ b/lib/git_chain/forge/gitlab.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "open3"
+require "json"
+
+module GitChain
+  module Forge
+    class Gitlab < Base
+      def cli_available?
+        command_available?("glab")
+      end
+
+      def pr_for_branch(branch_name)
+        out, _, stat = Open3.capture3(
+          "glab", "mr", "list",
+          "--source-branch", branch_name,
+          "--all",
+          "-F", "json"
+        )
+        return nil unless stat.success?
+
+        mrs = JSON.parse(out)
+        return nil if mrs.empty?
+
+        normalize(mrs.first)
+      rescue JSON::ParserError, Errno::ENOENT
+        nil
+      end
+
+      private
+
+      # glab returns state as "opened"/"merged"/"closed".
+      # Normalize to our uppercase format: OPEN/MERGED/CLOSED.
+      def normalize(mr)
+        {
+          number: mr["iid"],
+          state: normalize_state(mr["state"]),
+          is_draft: mr.fetch("draft", false),
+          review_decision: nil, # GitLab MRs don't have a direct equivalent
+        }
+      end
+
+      def normalize_state(state)
+        case state
+        when "opened" then "OPEN"
+        when "merged" then "MERGED"
+        when "closed" then "CLOSED"
+        else state.to_s.upcase
+        end
+      end
+    end
+  end
+end

--- a/lib/git_chain/git.rb
+++ b/lib/git_chain/git.rb
@@ -115,6 +115,14 @@ module GitChain
         current_vals.lines.map(&:strip)
       end
 
+      def ahead_behind(branch, upstream, dir: nil)
+        out = exec("rev-list", "--left-right", "--count", "#{upstream}...#{branch}", dir: dir)
+        behind, ahead = out.split("\t").map(&:to_i)
+        { ahead: ahead, behind: behind }
+      rescue Failure
+        nil
+      end
+
       def rebase_in_progress?(dir: nil)
         dir ||= ".git"
         !Dir.glob(File.join(File.expand_path(dir), "rebase-{apply,merge}")).empty?

--- a/test/git_chain/command/branch_test.rb
+++ b/test/git_chain/command/branch_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class BranchTest < MiniTest::Test
+    class BranchTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_append

--- a/test/git_chain/command/list_test.rb
+++ b/test/git_chain/command/list_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class ListTest < MiniTest::Test
+    class ListTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_append

--- a/test/git_chain/command/prune_test.rb
+++ b/test/git_chain/command/prune_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class PruneTest < MiniTest::Test
+    class PruneTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_clean_chain

--- a/test/git_chain/command/push_test.rb
+++ b/test/git_chain/command/push_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class PushTest < MiniTest::Test
+    class PushTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_push_nothing

--- a/test/git_chain/command/rebase_test.rb
+++ b/test/git_chain/command/rebase_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class RebaseTest < MiniTest::Test
+    class RebaseTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_rebasing_a_clean_chain

--- a/test/git_chain/command/setup_test.rb
+++ b/test/git_chain/command/setup_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class SetupTest < MiniTest::Test
+    class SetupTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_chain_noop

--- a/test/git_chain/command/status_test.rb
+++ b/test/git_chain/command/status_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module GitChain
+  module Commands
+    class StatusTest < Minitest::Test
+      include RepositoryTestHelper
+
+      def test_status_shows_chain_name
+        with_test_repository("a-b-chain") do
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          assert_match(/default/, out)
+        end
+      end
+
+      def test_status_shows_all_branches
+        with_test_repository("a-b-chain") do
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          assert_match(/master/, out)
+          assert_match(/a/, out)
+          assert_match(/b/, out)
+        end
+      end
+
+      def test_status_shows_current_branch_marker
+        with_test_repository("a-b-chain") do
+          # Fixture ends on branch 'b'
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          assert_match(/b.*HEAD/, out)
+        end
+      end
+
+      def test_status_shows_tree_connectors
+        with_test_repository("a-b-chain") do
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          # Middle branch gets a tee connector
+          assert_match(/\u251C\u2500\u2500/, out)
+          # Last branch gets an elbow connector
+          assert_match(/\u2514\u2500\u2500/, out)
+        end
+      end
+
+      def test_status_shows_ahead_count
+        with_test_repository("a-b-chain") do
+          # Each branch has commits ahead of its parent's branch point
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          assert_match(/ahead/, out)
+        end
+      end
+
+      def test_status_with_chain_name_option
+        with_test_repository("a-b-chain") do
+          out, _ = capture_io do
+            Status.new.call(["-c", "default", "--no-pr"])
+          end
+
+          assert_match(/default/, out)
+          assert_match(/master/, out)
+        end
+      end
+
+      def test_status_raises_when_not_in_chain
+        with_test_repository("a-b") do
+          capture_io do
+            err = assert_raises(Abort) do
+              Status.new.call(["--no-pr"])
+            end
+            assert_match(/not in a chain/, err.message)
+          end
+        end
+      end
+
+      def test_status_no_pr_flag_skips_pr_lookup
+        with_test_repository("a-b-chain") do
+          # Should not call gh at all
+          Status.any_instance.expects(:fetch_pr_info).never
+
+          out, _ = capture_io do
+            Status.new.call(["--no-pr"])
+          end
+
+          # Should still render branch info
+          assert_match(/master/, out)
+        end
+      end
+    end
+  end
+end

--- a/test/git_chain/command/teardown_test.rb
+++ b/test/git_chain/command/teardown_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Commands
-    class TeardownTest < MiniTest::Test
+    class TeardownTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_tearing_down_a_clean_chain

--- a/test/git_chain/entry_point_test.rb
+++ b/test/git_chain/entry_point_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 
 module GitChain
-  class EntryPointTest < MiniTest::Test
+  class EntryPointTest < Minitest::Test
     def test_commands
       refute_nil(EntryPoint.commands["setup"])
     end

--- a/test/git_chain/fixtures_test.rb
+++ b/test/git_chain/fixtures_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 
 module GitChain
-  class FixturesTest < MiniTest::Test
+  class FixturesTest < Minitest::Test
     include RepositoryTestHelper
 
     def test_with_test_repository

--- a/test/git_chain/forge/forge_test.rb
+++ b/test/git_chain/forge/forge_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module GitChain
+  module Forge
+    class ForgeTest < Minitest::Test
+      include RepositoryTestHelper
+
+      def test_detect_github_from_https_url
+        forge = Forge.send(:from_remote_url, "https://github.com/user/repo.git")
+        assert_instance_of(Github, forge)
+      end
+
+      def test_detect_github_from_ssh_url
+        forge = Forge.send(:from_remote_url, "git@github.com:user/repo.git")
+        assert_instance_of(Github, forge)
+      end
+
+      def test_detect_gitlab_from_https_url
+        forge = Forge.send(:from_remote_url, "https://gitlab.com/user/repo.git")
+        assert_instance_of(Gitlab, forge)
+      end
+
+      def test_detect_gitlab_from_ssh_url
+        forge = Forge.send(:from_remote_url, "git@gitlab.com:user/repo.git")
+        assert_instance_of(Gitlab, forge)
+      end
+
+      def test_detect_gitlab_self_hosted
+        forge = Forge.send(:from_remote_url, "https://gitlab.company.com/team/repo.git")
+        assert_instance_of(Gitlab, forge)
+      end
+
+      def test_detect_unknown_returns_nil
+        forge = Forge.send(:from_remote_url, "https://bitbucket.org/user/repo.git")
+        assert_nil(forge)
+      end
+
+      def test_detect_github_repo_with_gitlab_in_path
+        forge = Forge.send(:from_remote_url, "https://github.com/gitlab-org/repo.git")
+        assert_instance_of(Github, forge)
+      end
+
+      def test_detect_gitlab_ssh_self_hosted
+        forge = Forge.send(:from_remote_url, "git@gitlab.company.com:team/repo.git")
+        assert_instance_of(Gitlab, forge)
+      end
+
+      def test_detect_config_override_github
+        with_test_repository("a-b") do
+          Git.exec("config", "--local", "chain.forge", "github")
+          forge = Forge.detect(remote_url: "https://gitlab.com/user/repo.git")
+          assert_instance_of(Github, forge)
+        end
+      end
+
+      def test_detect_config_override_gitlab
+        with_test_repository("a-b") do
+          Git.exec("config", "--local", "chain.forge", "gitlab")
+          forge = Forge.detect(remote_url: "https://github.com/user/repo.git")
+          assert_instance_of(Gitlab, forge)
+        end
+      end
+    end
+  end
+end

--- a/test/git_chain/forge/github_test.rb
+++ b/test/git_chain/forge/github_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module GitChain
+  module Forge
+    class GithubTest < Minitest::Test
+      def test_cli_available
+        skip("gh not installed") unless gh_available?
+        github = Github.new
+        assert(github.cli_available?)
+      end
+
+      def test_pr_for_branch_no_match
+        skip("gh not installed") unless gh_available?
+        github = Github.new
+        result = github.pr_for_branch("nonexistent-branch-abc123xyz")
+        assert_nil(result)
+      end
+
+      def test_normalize_open_pr
+        github = Github.new
+        pr = github.send(:normalize, {
+          "number" => 42,
+          "state" => "OPEN",
+          "isDraft" => false,
+          "reviewDecision" => "APPROVED",
+        })
+
+        assert_equal(42, pr[:number])
+        assert_equal("OPEN", pr[:state])
+        assert_equal(false, pr[:is_draft])
+        assert_equal("APPROVED", pr[:review_decision])
+      end
+
+      def test_normalize_merged_pr
+        github = Github.new
+        pr = github.send(:normalize, {
+          "number" => 10,
+          "state" => "MERGED",
+          "isDraft" => false,
+          "reviewDecision" => nil,
+        })
+
+        assert_equal("MERGED", pr[:state])
+      end
+
+      def test_normalize_draft_pr
+        github = Github.new
+        pr = github.send(:normalize, {
+          "number" => 5,
+          "state" => "OPEN",
+          "isDraft" => true,
+          "reviewDecision" => nil,
+        })
+
+        assert_equal(true, pr[:is_draft])
+      end
+
+      private
+
+      def gh_available?
+        _, _, stat = Open3.capture3("gh", "--version")
+        stat.success?
+      rescue Errno::ENOENT
+        false
+      end
+    end
+  end
+end

--- a/test/git_chain/forge/gitlab_test.rb
+++ b/test/git_chain/forge/gitlab_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module GitChain
+  module Forge
+    class GitlabTest < Minitest::Test
+      def test_normalize_opened_state
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 42,
+          "state" => "opened",
+          "draft" => false,
+        })
+
+        assert_equal(42, mr[:number])
+        assert_equal("OPEN", mr[:state])
+        assert_equal(false, mr[:is_draft])
+        assert_nil(mr[:review_decision])
+      end
+
+      def test_normalize_merged_state
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 10,
+          "state" => "merged",
+          "draft" => false,
+        })
+
+        assert_equal("MERGED", mr[:state])
+      end
+
+      def test_normalize_closed_state
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 3,
+          "state" => "closed",
+          "draft" => false,
+        })
+
+        assert_equal("CLOSED", mr[:state])
+      end
+
+      def test_normalize_draft_mr
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 7,
+          "state" => "opened",
+          "draft" => true,
+        })
+
+        assert_equal(true, mr[:is_draft])
+      end
+
+      def test_normalize_missing_draft_field
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 7,
+          "state" => "opened",
+        })
+
+        assert_equal(false, mr[:is_draft])
+      end
+
+      def test_review_decision_always_nil
+        gitlab = Gitlab.new
+        mr = gitlab.send(:normalize, {
+          "iid" => 1,
+          "state" => "opened",
+          "draft" => false,
+        })
+
+        assert_nil(mr[:review_decision])
+      end
+    end
+  end
+end

--- a/test/git_chain/git_test.rb
+++ b/test/git_chain/git_test.rb
@@ -2,12 +2,28 @@
 require "test_helper"
 
 module GitChain
-  class GitTest < MiniTest::Test
+  class GitTest < Minitest::Test
     include RepositoryTestHelper
 
     def test_chains
       with_test_repository("a-b-chain") do
         assert_equal({ "a" => "default", "b" => "default" }, Git.chains)
+      end
+    end
+
+    def test_ahead_behind
+      with_test_repository("a-b-chain") do
+        counts = Git.ahead_behind("a", "master")
+        assert_instance_of(Hash, counts)
+        assert(counts[:ahead] >= 0)
+        assert(counts[:behind] >= 0)
+      end
+    end
+
+    def test_ahead_behind_invalid_ref
+      with_test_repository("a-b-chain") do
+        result = Git.ahead_behind("nonexistent", "master")
+        assert_nil(result)
       end
     end
   end

--- a/test/git_chain/model/branch_test.rb
+++ b/test/git_chain/model/branch_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Models
-    class BranchTest < MiniTest::Test
+    class BranchTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_from_config

--- a/test/git_chain/model/chain_test.rb
+++ b/test/git_chain/model/chain_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Models
-    class ChainTest < MiniTest::Test
+    class ChainTest < Minitest::Test
       include RepositoryTestHelper
 
       def test_from_config

--- a/test/git_chain/rebase_test.rb
+++ b/test/git_chain/rebase_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 
 module GitChain
-  class RebaseTest < MiniTest::Test
+  class RebaseTest < Minitest::Test
     def test_rebase
       assert(true)
     end

--- a/test/git_chain/util/github_test.rb
+++ b/test/git_chain/util/github_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module GitChain
   module Util
-    class GithubTest < MiniTest::Test
+    class GithubTest < Minitest::Test
       def test_parse_url
         %w(
           git@github.com:Shopify/git-chain.git

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require "mocha/minitest"
 require "minitest/autorun"
 require "minitest/reporters"
 
-MiniTest::Reporters.use!
+Minitest::Reporters.use!
 CLI::UI.enable_color = true
 
 require "tmpdir"


### PR DESCRIPTION
## Summary

- Add `git chain status` command that displays a tree view of all branches in a chain with ahead/behind counts, HEAD marker, and optional PR/MR status
- Add `Forge` module that auto-detects GitHub/GitLab from the remote URL and dispatches PR lookups to `gh`/`glab`
- Fix Ruby 4.0 compatibility (logger gem, Minitest constant casing)

## Changes

### `git chain status` (Closes #2)

Displays a tree view of the current chain:

```
my-feature
  main
  ├── feature-auth (2 ahead, #10 open)
  ├── feature-api (HEAD) (1 ahead, #11 open)
  └── feature-ui (1 ahead, #12 draft)
```

Options:
- `--no-pr` skips forge CLI lookups
- `-c NAME` targets a specific chain

### Forge abstraction (Refs #8)

- `Forge.detect` parses the remote URL hostname to select GitHub or GitLab
- `git config chain.forge` override for custom domains (e.g., GitHub Enterprise)
- Common interface: `cli_available?`, `pr_for_branch(name)`
- State normalization across forges (OPEN/MERGED/CLOSED)

### Ruby 4.0 compatibility

- Add `logger` gem (removed from stdlib)
- Fix `MiniTest` -> `Minitest` (constant alias removed)
- Regenerate `Gemfile.lock`

## Test plan

59 tests, 166 assertions, 0 failures, 0 errors.